### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/Expenses.Api/Middleware/LogRequestMiddleware.cs
+++ b/Expenses.Api/Middleware/LogRequestMiddleware.cs
@@ -14,9 +14,11 @@ public class LogRequestMiddleware(
 
         var correlationId = correlationContext.CorrelationContext.CorrelationId;
 
+        var sanitizedMethod = context.Request.Method.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+
         logger.LogInformation(
             "Scheme: {scheme}, Host: {host}, Path: {path}, Method: {method}, url: {url}, correlationId: {correlationId}",
-            context.Request.Scheme, context.Request.Host, context.Request.Path, context.Request.Method, url,
+            context.Request.Scheme, context.Request.Host, context.Request.Path, sanitizedMethod, url,
             correlationId);
 
         await next(context);


### PR DESCRIPTION
Potential fix for [https://github.com/omarRamo/expenses_api_net9/security/code-scanning/4](https://github.com/omarRamo/expenses_api_net9/security/code-scanning/4)

To fix the problem, we need to sanitize the `context.Request.Method` before logging it. Since the log entries are plain text, we should remove any line breaks from the user input to prevent log forging. We can use the `String.Replace` method to achieve this.

- We will sanitize the `context.Request.Method` by replacing any newline characters with an empty string.
- This change will be made in the `Invoke` method of the `LogRequestMiddleware` class.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
